### PR TITLE
add core.Command library

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executable
   (name main)
-  (libraries lib))
+  (libraries core lib))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,29 +1,39 @@
 open Lib
+open Core
 
 let start () =
-  let pid = Process.start () in
-  Printf.printf "Timer started (pid=%d).\n" pid
+  Command.basic ~summary:"start a new pomodoro"
+    (Command.Param.return (fun () ->
+         let pid = Process.start () in
+         Printf.printf "Timer started (pid=%d).\n" pid))
 
 let run () =
-  let config = Config.read_file () in
-  let initial_timer = Timer.initial_timer config in
-  let broadcaster = Socket.create_and_accept () in
-  Timer.run config initial_timer broadcaster
+  Command.basic ~summary:"start and watch a pomodoro"
+    (Command.Param.return (fun () ->
+         let config = Config.read_file () in
+         let initial_timer = Timer.initial_timer config in
+         let broadcaster = Socket.create_and_accept () in
+         Timer.run config initial_timer broadcaster))
 
 let watch () =
-  let handler data = print_endline data in
-  Socket.connect_and_listen handler
+  Command.basic ~summary:"watch an existing pomodoro"
+    (Command.Param.return (fun () ->
+         let handler data = print_endline data in
+         Socket.connect_and_listen handler))
 
 let stop () =
-  Process.stop ();
-  print_endline "Timer stopped."
+  Command.basic ~summary:"stop a pomodoro"
+    (Command.Param.return (fun () ->
+         Process.stop ();
+         print_endline "Timer stopped."))
 
 let () =
-  let argv_last_idx = Array.length Sys.argv - 1 in
-  let arg_list = Array.to_list @@ Array.sub Sys.argv 1 argv_last_idx in
-  match arg_list with
-  | "start" :: _ -> start ()
-  | "run" :: _ -> run ()
-  | "watch" :: _ -> watch ()
-  | "stop" :: _ -> stop ()
-  | _ -> print_endline "Command not found"
+  Command.run
+    (Command.group
+       ~summary:"Socket-based CLI timer following the Pomodoro principles"
+       [
+         ("start", start ());
+         ("run", run ());
+         ("watch", watch ());
+         ("stop", stop ());
+       ])

--- a/comodoro.opam
+++ b/comodoro.opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "4.11.1"}
   "dune" {>= "2.7" & >= "2.7.1"}
   "base"
+  "core"
   "stdio"
   "toml"
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -15,6 +15,7 @@
   (ocaml (>= 4.11.1))
   (dune (>= 2.7.1))
   base
+  core
   stdio
   toml
  ))


### PR DESCRIPTION
This adds Janestreet `core.Command` library for CLI parsing, you can read more about it's usage [here](https://dev.realworldocaml.org/command-line-parsing.html).